### PR TITLE
Add support for tjenestepensjon-simulering

### DIFF
--- a/.nais/dev-fss-multienv.yml
+++ b/.nais/dev-fss-multienv.yml
@@ -124,5 +124,5 @@ spec:
         mountPath: /secrets/serviceuser
       - kvPath: /serviceuser/data/dev/srvpensjon
         mountPath: /secrets/serviceuser2
-      - kvPath: /serviceuser/data/dev/srvtjenestepensjon
+      - kvPath: /serviceuser/data/dev/srvtjenestepensjon-simulering
         mountPath: /secrets/serviceuser3

--- a/.nais/dev-fss-multienv.yml
+++ b/.nais/dev-fss-multienv.yml
@@ -124,3 +124,5 @@ spec:
         mountPath: /secrets/serviceuser
       - kvPath: /serviceuser/data/dev/srvpensjon
         mountPath: /secrets/serviceuser2
+      - kvPath: /serviceuser/data/dev/srvtjenestepensjon
+        mountPath: /secrets/serviceuser3

--- a/.nais/dev-fss.yml
+++ b/.nais/dev-fss.yml
@@ -129,5 +129,5 @@ spec:
         mountPath: /secrets/serviceuser
       - kvPath: /serviceuser/data/dev/srvpensjon
         mountPath: /secrets/serviceuser2
-      - kvPath: /serviceuser/data/dev/srvtjenestepensjon
+      - kvPath: /serviceuser/data/dev/srvtjenestepensjon-simulering
         mountPath: /secrets/serviceuser3

--- a/.nais/dev-fss.yml
+++ b/.nais/dev-fss.yml
@@ -129,3 +129,5 @@ spec:
         mountPath: /secrets/serviceuser
       - kvPath: /serviceuser/data/dev/srvpensjon
         mountPath: /secrets/serviceuser2
+      - kvPath: /serviceuser/data/dev/srvtjenestepensjon
+        mountPath: /secrets/serviceuser3

--- a/.nais/prod-fss.yml
+++ b/.nais/prod-fss.yml
@@ -120,5 +120,5 @@ spec:
         mountPath: /secrets/serviceuser
       - kvPath: /serviceuser/data/prod/srvpensjon
         mountPath: /secrets/serviceuser2
-      - kvPath: /serviceuser/data/prod/srvtjenestepensjon
+      - kvPath: /serviceuser/data/prod/srvtjenestepensjon-simulering
         mountPath: /secrets/serviceuser3

--- a/.nais/prod-fss.yml
+++ b/.nais/prod-fss.yml
@@ -120,3 +120,5 @@ spec:
         mountPath: /secrets/serviceuser
       - kvPath: /serviceuser/data/prod/srvpensjon
         mountPath: /secrets/serviceuser2
+      - kvPath: /serviceuser/data/prod/srvtjenestepensjon
+        mountPath: /secrets/serviceuser3

--- a/init.sh
+++ b/init.sh
@@ -6,3 +6,7 @@ SERVICEUSER2_USERNAME=$(cat /secrets/serviceuser2/username) || true
 export SERVICEUSER2_USERNAME
 SERVICEUSER2_PASSWORD=$(cat /secrets/serviceuser2/password) || true
 export SERVICEUSER2_PASSWORD
+SERVICEUSER3_USERNAME=$(cat /secrets/serviceuser3/username) || true
+export SERVICEUSER3_USERNAME
+SERVICEUSER3_PASSWORD=$(cat /secrets/serviceuser3/password) || true
+export SERVICEUSER3_PASSWORD

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/ControllerBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/ControllerBase.kt
@@ -37,7 +37,7 @@ abstract class ControllerBase(
 
         return try {
             val authorizedParty = checkIngressAuth(request)
-            val headersToRelay = getEgressHeaders(request, useServiceUser2 = false)
+            val headersToRelay = getEgressHeaders(request, serviceUserId = 1)
             val queryPart = if (hasText(request.queryString)) "?${request.queryString}" else ""
             val url = "$egressEndpoint${request.requestURI}$queryPart"
             val responseBody = serviceClient.doGet(url, headersToRelay)
@@ -61,7 +61,7 @@ abstract class ControllerBase(
 
         return try {
             val authorizedParty = checkIngressAuth(request)
-            val headersToRelay = getEgressHeaders(request, useServiceUser2 = false)
+            val headersToRelay = getEgressHeaders(request, serviceUserId = 1)
             val queryPart = if (hasText(request.queryString)) "?${request.queryString}" else ""
             val url = "$egressEndpoint${request.requestURI}$queryPart"
             val responseBody = serviceClient.doOptions(url, headersToRelay)
@@ -80,12 +80,12 @@ abstract class ControllerBase(
         }
     }
 
-    fun doPost(request: HttpServletRequest, body: String, useServiceUser2: Boolean = false): ResponseEntity<String> {
+    fun doPost(request: HttpServletRequest, body: String, serviceUserId: Int = 1): ResponseEntity<String> {
         val responseContentType = getResponseContentType(request)
 
         return try {
             val authorizedParty = checkIngressAuth(request)
-            val headersToRelay = getEgressHeaders(request, useServiceUser2)
+            val headersToRelay = getEgressHeaders(request, serviceUserId)
             val queryPart = if (hasText(request.queryString)) "?${request.queryString}" else ""
             val url = "$egressEndpoint${request.requestURI}$queryPart"
             val responseBody = serviceClient.doPost(url, headersToRelay, provideBodyAuth(body))
@@ -109,17 +109,17 @@ abstract class ControllerBase(
     protected abstract fun provideHeaderAuth(
         request: HttpServletRequest,
         headers: TreeMap<String, String>,
-        useServiceUser2: Boolean
+        serviceUserId: Int
     )
 
     protected abstract fun provideBodyAuth(body: String): String
 
     protected open fun metricDetail(request: HttpServletRequest): String = request.requestURI
 
-    private fun getEgressHeaders(request: HttpServletRequest, useServiceUser2: Boolean): TreeMap<String, String> {
+    private fun getEgressHeaders(request: HttpServletRequest, serviceUserId: Int): TreeMap<String, String> {
         val egressHeaders = TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER)
         request.headerNames.toList().forEach { copyHeader(request, it, egressHeaders) }
-        provideHeaderAuth(request, egressHeaders, useServiceUser2)
+        provideHeaderAuth(request, egressHeaders, serviceUserId)
         addCallIdHeader(egressHeaders)
         return egressHeaders
     }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/EgressBodyAuthController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/EgressBodyAuthController.kt
@@ -24,7 +24,7 @@ abstract class EgressBodyAuthController(
     override fun provideHeaderAuth(
         request: HttpServletRequest,
         headers: TreeMap<String, String>,
-        useServiceUser2: Boolean
+        serviceUserId: Int
     ) {
         // No auth header – auth is instead provided in SOAP header (in HTTP body)
     }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/EgressHeaderAuthController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/EgressHeaderAuthController.kt
@@ -23,9 +23,9 @@ abstract class EgressHeaderAuthController(
     override fun provideHeaderAuth(
         request: HttpServletRequest,
         headers: TreeMap<String, String>,
-        useServiceUser2: Boolean
+        serviceUserId: Int
     ) {
-        val token = egressTokenGetter.getServiceUserToken(useServiceUser2).accessToken
+        val token = egressTokenGetter.getServiceUserToken(serviceUserId).accessToken
         val auth = "$AUTH_TYPE $token"
         headers[HttpHeaders.AUTHORIZATION] = auth
 

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/EgressHeaderBasicAuthController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/EgressHeaderBasicAuthController.kt
@@ -22,7 +22,7 @@ abstract class EgressHeaderBasicAuthController(
     override fun provideHeaderAuth(
         request: HttpServletRequest,
         headers: TreeMap<String, String>,
-        useServiceUser2: Boolean
+        serviceUserId: Int
     ) {
         headers[HttpHeaders.AUTHORIZATION] = "$AUTH_TYPE $credentials"
     }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/EgressNoAuthController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/EgressNoAuthController.kt
@@ -17,7 +17,7 @@ abstract class EgressNoAuthController(
     override fun provideHeaderAuth(
         request: HttpServletRequest,
         headers: TreeMap<String, String>,
-        useServiceUser2: Boolean
+        serviceUserId: Int
     ) {
         // No operation
     }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/UnprotectedControllerBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/common/UnprotectedControllerBase.kt
@@ -16,7 +16,7 @@ abstract class UnprotectedControllerBase(
     override fun provideHeaderAuth(
         request: HttpServletRequest,
         headers: TreeMap<String, String>,
-        useServiceUser2: Boolean
+        serviceUserId: Int
     ) {
         // No operation
     }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/esb/EsbController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/esb/EsbController.kt
@@ -37,7 +37,7 @@ class EsbController(
     )
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> {
         logger.info("Request url: ${request.requestURL}")
-        return super.doPost(request, body, useServiceUser2 = false)
+        return super.doPost(request, body, serviceUserId = 1)
 
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/esb/EsbSelfTestController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/esb/EsbSelfTestController.kt
@@ -23,5 +23,5 @@ class EsbSelfTestController(
 ) {
     @PostMapping("nav-cons-test-getapplicationversionWeb/sca/TESTGetApplicationVersionWSEXP")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/inntekt/InntektController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/inntekt/InntektController.kt
@@ -34,7 +34,7 @@ class InntektController(
             "${PATH}hentdetaljerteabonnerteinntekter",
             "${PATH}hentabonnerteinntekterbolk"])
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 
     override fun consumerTokenRequired(): Boolean = true
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/journalforing/JournalforingController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/journalforing/JournalforingController.kt
@@ -26,7 +26,7 @@ class JournalforingController(
 ) {
     @PostMapping("v1/journalpost")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 
     override fun consumerTokenRequired(): Boolean = false
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/org/ws/OrganisasjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/org/ws/OrganisasjonController.kt
@@ -25,5 +25,5 @@ class OrganisasjonController(
 ) {
     @PostMapping("v4")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/partner/PepGatewayController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/partner/PepGatewayController.kt
@@ -30,5 +30,5 @@ class PepGatewayController(
             "privat.pensjonsrettighetstjeneste/privatPensjonTjenesteV2_0"
         ])
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/partner/TjenestepensjonPepGatewayController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/partner/TjenestepensjonPepGatewayController.kt
@@ -1,32 +1,30 @@
-package no.nav.pensjon.selvbetjening.fssgw.inntekt.ws
+package no.nav.pensjon.selvbetjening.fssgw.partner
 
 import no.nav.pensjon.selvbetjening.fssgw.common.CallIdGenerator
-import no.nav.pensjon.selvbetjening.fssgw.common.EgressBodyAuthController
+import no.nav.pensjon.selvbetjening.fssgw.common.EgressNoAuthController
 import no.nav.pensjon.selvbetjening.fssgw.common.ServiceClient
 import no.nav.pensjon.selvbetjening.fssgw.tech.jwt.JwsValidator
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import jakarta.servlet.http.HttpServletRequest
 
+/**
+ * PEP = Policy enforcement point
+ * Requires no additional auth to be inserted (hence EgressNoAuthController)
+ */
 @RestController
-@RequestMapping("inntektskomponenten-ws/inntekt")
-class InntektWebServiceController(
+class TjenestepensjonPepGatewayController(
     ingressTokenValidator: JwsValidator,
     serviceClient: ServiceClient,
     callIdGenerator: CallIdGenerator,
-    @Value("\${app.url}") egressEndpoint: String,
-    @Value("\${sts.password}") private val password: String
-) : EgressBodyAuthController(
-    ingressTokenValidator, serviceClient, callIdGenerator, egressEndpoint, password
+    @Value("\${pep-gw.url}") egressEndpoint: String
+) : EgressNoAuthController(
+    ingressTokenValidator, serviceClient, callIdGenerator, egressEndpoint
 ) {
-    @PostMapping(
-        value = [
-            "v3/Inntekt",
-            "BehandleInntekt"])
+    @PostMapping("ekstern-pensjon-tjeneste-tjenestepensjonSimuleringWeb/sca/TjenestepensjonSimuleringWSEXP")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> =
-        super.doPost(request, body, serviceUserId = 1)
+        super.doPost(request, body, serviceUserId = 3)
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/pen/PenController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/pen/PenController.kt
@@ -42,7 +42,7 @@ class PenController(
             "springapi/uttaksalder"
         ])
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest) =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 
     override fun consumerTokenRequired() = false
 

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/popp/PoppController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/popp/PoppController.kt
@@ -30,7 +30,7 @@ class PoppController(
 
     @PostMapping("api/beholdning")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 
     override fun consumerTokenRequired(): Boolean = false
 

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/regler/PensjonReglerController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/regler/PensjonReglerController.kt
@@ -35,5 +35,5 @@ class PensjonReglerController(
             "api/simulerAlderspensjon",
             "api/vilkarsprovAlderspensjonOver67"])
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest): ResponseEntity<String> =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/sporing/SporingsloggController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/sporing/SporingsloggController.kt
@@ -23,7 +23,7 @@ class SporingsloggController(
 ) {
     @PostMapping("sporingslogg")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest) =
-        super.doPost(request, body, useServiceUser2 = true)
+        super.doPost(request, body, serviceUserId = 2)
 
     override fun consumerTokenRequired() = false
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/sts/StsController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/sts/StsController.kt
@@ -25,5 +25,5 @@ class StsController(
 
     @PostMapping("token/exchange")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest) =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/tech/sts/ServiceTokenGetter.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/tech/sts/ServiceTokenGetter.kt
@@ -2,5 +2,5 @@ package no.nav.pensjon.selvbetjening.fssgw.tech.sts
 
 fun interface ServiceTokenGetter {
 
-    fun getServiceUserToken(useServiceUser2: Boolean): ServiceTokenData
+    fun getServiceUserToken(serviceUserId: Int): ServiceTokenData
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/tss/TssController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/tss/TssController.kt
@@ -28,7 +28,7 @@ class TssController(
 ) {
     @PostMapping("hentSamhandler")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest) =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 
     override fun consumerTokenRequired() = false
 }

--- a/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/vedtak/ws/VedtakController.kt
+++ b/src/main/kotlin/no/nav/pensjon/selvbetjening/fssgw/vedtak/ws/VedtakController.kt
@@ -25,5 +25,5 @@ class VedtakController(
 
     @PostMapping("Vedtak_v2")
     fun handlePostRequest(@RequestBody body: String, request: HttpServletRequest) =
-        super.doPost(request, body, useServiceUser2 = false)
+        super.doPost(request, body, serviceUserId = 1)
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,8 @@ sts.username=${SERVICEUSER_USERNAME:srvpselv}
 sts.password=${SERVICEUSER_PASSWORD:&secret}
 sts.username2=${SERVICEUSER2_USERNAME:srvpensjon}
 sts.password2=${SERVICEUSER2_PASSWORD:&secret}
+sts.username3=${SERVICEUSER3_USERNAME:srvtjenestepensjon}
+sts.password3=${SERVICEUSER3_PASSWORD:&secret}
 sts.token.expiration.leeway=60
 
 http.proxy.uri=${HTTP_PROXY:notinuse}

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/ereg/EregControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/ereg/EregControllerTest.kt
@@ -45,7 +45,7 @@ internal class EregControllerTest {
     fun `Ereg request results in JSON response`() {
         val expectedIdent = "00000000000"
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "bar"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/fullmakt/PensjonFullmaktControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/fullmakt/PensjonFullmaktControllerTest.kt
@@ -46,7 +46,7 @@ internal class PensjonFullmaktControllerTest {
     @Test
     fun `when OK then finnFullmakter request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn(responseFinnFullmakterBody())
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -61,7 +61,7 @@ internal class PensjonFullmaktControllerTest {
     @Test
     fun `when OK then harFullmaktsforhold request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn(responseHarFullmaktsforholdBody())
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/inntekt/InntektControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/inntekt/InntektControllerTest.kt
@@ -47,7 +47,7 @@ internal class InntektControllerTest {
     @Test
     fun `when OK then ForventedeInntekter request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "ForventedeInntekter"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -64,7 +64,7 @@ internal class InntektControllerTest {
     fun `when OK then ForventedeInntekter post returns data`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString()))
             .thenReturn("""{ "response": "ForventedeInntekter"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -79,7 +79,7 @@ internal class InntektControllerTest {
     fun `when OK then hentdetaljerteabonnerteinntekter post returns data`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString()))
             .thenReturn("""{ "response": "hentdetaljerteabonnerteinntekter"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -94,7 +94,7 @@ internal class InntektControllerTest {
     fun `when OK then hentabonnerteinntekterbolk post returns data`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString()))
             .thenReturn("""{ "response": "hentabonnerteinntekterbolk"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/inntekt/InntektPingRsControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/inntekt/InntektPingRsControllerTest.kt
@@ -46,7 +46,7 @@ internal class InntektPingRsControllerTest {
     @Test
     fun `when OK then Inntekt ping request responds with OK`() {
         `when`(serviceClient.doGet(anyString(), ArgumentMatchers.anyMap())).thenReturn("""{ "response": "pong"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/inntekt/ws/InntektWebServiceControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/inntekt/ws/InntektWebServiceControllerTest.kt
@@ -45,7 +45,7 @@ internal class InntektWebServiceControllerTest {
     @Test
     fun `inntekt request results in inntekt response XML`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString())).thenReturn(RESPONSE_BODY)
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
         val expectedMediaType = MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8)
 
@@ -71,7 +71,7 @@ internal class InntektWebServiceControllerTest {
     @Test
     fun `behandleInntekt request results in behandleInntekt response XML`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString())).thenReturn(RESPONSE_BODY)
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
         val expectedMediaType = MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8)
 

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/journalforing/JournalforingControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/journalforing/JournalforingControllerTest.kt
@@ -44,7 +44,7 @@ internal class JournalforingControllerTest {
     @Test
     fun `Journalforing request results in JSON response`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString())).thenReturn("""{ "response": "bar"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/org/ws/OrganisasjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/org/ws/OrganisasjonControllerTest.kt
@@ -45,7 +45,7 @@ internal class OrganisasjonControllerTest {
     @Test
     fun `service request results in service response XML`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString())).thenReturn(RESPONSE_BODY)
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
         val expectedMediaType = MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8)
 

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/pen/PenControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/pen/PenControllerTest.kt
@@ -49,7 +49,7 @@ internal class PenControllerTest {
     @Test
     fun `when OK then AFP-historikk request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "AFP-historikken"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -63,7 +63,7 @@ internal class PenControllerTest {
     @Test
     fun `when OK then uforehistorikk request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "uførehistorikken"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -77,7 +77,7 @@ internal class PenControllerTest {
     @Test
     fun `when OK then uttaksgrad person request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "uttaksgraden"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -91,7 +91,7 @@ internal class PenControllerTest {
     @Test
     fun `when OK then uttaksgrad search request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "uttaksgradene"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -104,7 +104,7 @@ internal class PenControllerTest {
     @Test
     fun `when OK then krav request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "kravet"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -119,7 +119,7 @@ internal class PenControllerTest {
     @Test
     fun `when OK then sakssammendrag request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "sammendraget"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -135,7 +135,7 @@ internal class PenControllerTest {
     fun `when OK then vedtak request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap()))
             .thenReturn("""{ "response": "vedtakene"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -151,7 +151,7 @@ internal class PenControllerTest {
     fun `when OK then bestem gjeldende vedtak request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap()))
             .thenReturn("""{ "response": "vedtakene"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -168,7 +168,7 @@ internal class PenControllerTest {
     fun `when 4xx error then PEN request responds with 4xx and error message`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString()))
             .thenAnswer { throw EgressException("""{"error": "oops"}""", HttpStatus.CONFLICT) }
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -183,7 +183,7 @@ internal class PenControllerTest {
     fun `when 5xx error then PEN request responds with 502 and error message`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString()))
             .thenAnswer { throw EgressException("""{"error": "oops"}""", HttpStatus.INTERNAL_SERVER_ERROR) }
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/pen/PenPingControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/pen/PenPingControllerTest.kt
@@ -45,7 +45,7 @@ internal class PenPingControllerTest {
     @Test
     fun `when OK then Spring API ping request responds with OK`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("Ok")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -60,7 +60,7 @@ internal class PenPingControllerTest {
     fun `when error then Spring API ping request responds with bad gateway and error message`() {
         `when`(serviceClient.doGet(anyString(), anyMap()))
             .thenAnswer { throw EgressException("""{"error": "oops"}""") }
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/popp/PoppControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/popp/PoppControllerTest.kt
@@ -47,7 +47,7 @@ internal class PoppControllerTest {
     @Test
     fun `when OK then opptjeningsgrunnlag request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "opptjeningsgrunnlaget"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -60,7 +60,7 @@ internal class PoppControllerTest {
     @Test
     fun `when OK then pensjonspoeng request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "pensjonspoengene"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -73,7 +73,7 @@ internal class PoppControllerTest {
     @Test
     fun `when OK then restpensjon request returns data`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "response": "restpensjonen"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(
@@ -86,7 +86,7 @@ internal class PoppControllerTest {
     @Test
     fun `when OK then beholdning request returns data`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString())).thenReturn("""{ "response": "beholdningen"}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/sporing/SporingsloggControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/sporing/SporingsloggControllerTest.kt
@@ -45,7 +45,7 @@ internal class SporingsloggControllerTest {
     @Test
     fun `handlePostRequest request results in JSON response`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString())).thenReturn(RESPONSE_BODY)
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = true)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 2)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/sts/StsControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/sts/StsControllerTest.kt
@@ -44,7 +44,7 @@ internal class StsControllerTest {
     @Test
     fun `access token request results in JWT access token response`() {
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn(JWT_ACCESS_TOKEN_RESPONSE_BODY)
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
 
         mvc.perform(

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/tech/sts/StsClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/tech/sts/StsClientTest.kt
@@ -31,14 +31,16 @@ internal class StsClientTest : WebClientTest() {
             serviceUsername = "username1",
             servicePassword = "password1",
             serviceUsername2 = "username2",
-            servicePassword2 = "password2")
+            servicePassword2 = "password2",
+            serviceUsername3 = "username3",
+            servicePassword3 = "password3")
     }
 
     @Test
     fun getServiceUserToken_returns_tokenData_when_ok() {
         prepare(response1())
 
-        val token: ServiceTokenData = consumer.getServiceUserToken(useServiceUser2 = false)
+        val token: ServiceTokenData = consumer.getServiceUserToken(serviceUserId = 1)
 
         assertEquals("j.w.t", token.accessToken)
         assertEquals(3600L, token.expiresInSeconds)
@@ -50,9 +52,9 @@ internal class StsClientTest : WebClientTest() {
     fun getServiceUserToken_caches_tokenData() {
         prepare(response1())
 
-        val token: ServiceTokenData = consumer.getServiceUserToken(useServiceUser2 = false)
+        val token: ServiceTokenData = consumer.getServiceUserToken(serviceUserId = 1)
         // Next line will fail if not cached, since only one response is queued:
-        val cachedToken: ServiceTokenData = consumer.getServiceUserToken(useServiceUser2 = false)
+        val cachedToken: ServiceTokenData = consumer.getServiceUserToken(serviceUserId = 1)
 
         assertEquals("j.w.t", token.accessToken)
         assertEquals("j.w.t", cachedToken.accessToken)
@@ -63,9 +65,9 @@ internal class StsClientTest : WebClientTest() {
         prepare(response1())
         prepare(response2())
 
-        val token1: ServiceTokenData = consumer.getServiceUserToken(useServiceUser2 = false)
+        val token1: ServiceTokenData = consumer.getServiceUserToken(serviceUserId = 1)
         expireToken()
-        val token2: ServiceTokenData = consumer.getServiceUserToken(useServiceUser2 = false)
+        val token2: ServiceTokenData = consumer.getServiceUserToken(serviceUserId = 1)
 
         assertEquals("j.w.t", token1.accessToken)
         assertEquals("jj.ww.tt", token2.accessToken)

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/tjenestepensjon/TjenestepensjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/tjenestepensjon/TjenestepensjonControllerTest.kt
@@ -47,7 +47,7 @@ class TjenestepensjonControllerTest {
     fun `when OK then haveYtelse request returns data`() {
         val egressToken = serviceTokenData()
         `when`(serviceClient.doGet(anyString(), anyMap())).thenReturn("""{ "value": true}""")
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(egressToken)
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(egressToken)
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
         `when`(callIdGenerator.newCallId()).thenReturn(CALL_ID)
 

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/tss/TssControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/tss/TssControllerTest.kt
@@ -45,7 +45,7 @@ internal class TssControllerTest {
     @Test
     fun `hentSamhandler request results in samhandler response XML`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString())).thenReturn(RESPONSE_BODY)
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
         val expectedMediaType = MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8)
 

--- a/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/vedtak/ws/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/selvbetjening/fssgw/vedtak/ws/VedtakControllerTest.kt
@@ -45,7 +45,7 @@ internal class VedtakControllerTest {
     @Test
     fun `vedtak request results in vedtak response XML`() {
         `when`(serviceClient.doPost(anyString(), anyMap(), anyString())).thenReturn(RESPONSE_BODY)
-        `when`(egressTokenGetter.getServiceUserToken(useServiceUser2 = false)).thenReturn(serviceTokenData())
+        `when`(egressTokenGetter.getServiceUserToken(serviceUserId = 1)).thenReturn(serviceTokenData())
         `when`(ingressTokenValidator.validate(anyString())).thenReturn(claims)
         val expectedMediaType = MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8)
 


### PR DESCRIPTION
Må håndtere nok en servicebruker (`srvtjenestepensjon`).
Innfører derfor "serviceuser ID" (for enkelhets skyld en integer):

- ID = 1: `srvpselv`
- ID = 2: `srvpensjon`
- ID = 3: `srvtjenestepensjon`