### PR TITLE
Bump oauth2-oidc-sdk to 11.37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.5</version>
         <relativePath/> <!-- lookup parent from the repository -->
     </parent>
     <groupId>no.nav.pensjon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-extensions-spring</artifactId>
-            <version>6.1.4</version>
+            <version>6.1.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>11.33</version>
+            <version>11.37</version>
         </dependency>
         <dependency>
             <groupId>io.github.microutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-runner-junit5</artifactId>
-            <version>6.1.4</version>
+            <version>6.1.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bump:
* oauth2-oidc-sdk from 11.33 to 11.37
* spring-boot-starter-parent from 4.0.3 to 4.0.5
* kotest-extensions-spring from 6.1.4 to 6.1.9
* kotest-runner-junit5 from 6.1.4 to 6.1.9